### PR TITLE
fluidctl: update OpenAPI spec

### DIFF
--- a/cmd/fluidctl/api.yaml
+++ b/cmd/fluidctl/api.yaml
@@ -446,48 +446,6 @@ paths:
                   - capacity
         '500':
           description: Server error
-  /session:
-    post:
-      summary: Create a session
-      tags:
-        - Session
-      requestBody:
-        description: User credentials for session creation
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                username:
-                  type: string
-                  description: The username of the user
-                  example: admin
-                password:
-                  type: string
-                  description: The password of the user
-                  example: password123
-              required:
-                - username
-                - password
-      responses:
-        '200':
-          description: Session created successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  token:
-                    type: string
-                    description: Authentication token
-                    example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1Njc4MTIzODcsImlzcyI6ImF0bGFzIiwibmJmIjoxNTY3ODEyMzg3LCJzdWIiOiJhZG1pbiJ9.ejyTgFxLhuY9mOBtKhcnvobg3QZXJ4_RusN_KIdVwao
-        '400':
-          description: Invalid input
-        '401':
-          description: Unauthorized
-        '500':
-          description: Server error
 components:
   securitySchemes:
     bearerAuth:
@@ -699,4 +657,3 @@ components:
       description: Organization identifier passed as a header. This is optional and can normally inferred by the bearer token used for authentication.
       schema:
         type: string
-        format: uuid


### PR DESCRIPTION
Update OpenAPI spec to remove deprecated 'sessions' endpoint. We use OIDC for all auth.