### PR TITLE
fluidctl: add support for client credentials flow

### DIFF
--- a/cmd/fluidctl/main.go
+++ b/cmd/fluidctl/main.go
@@ -28,6 +28,8 @@ func rootCommand() *cobra.Command {
 	cmd.PersistentFlags().StringP("url", "U", "https://atlas.fluidstack.io", "Atlas Server URL")
 	cmd.PersistentFlags().StringP("format", "F", "yaml", "Output format (json, yaml)")
 	cmd.PersistentFlags().StringP("token", "T", "", "Auth token")
+	cmd.PersistentFlags().String("client-id", "", "OAuth Client ID")
+	cmd.PersistentFlags().String("client-secret", "", "OAuth Client Secret")
 
 	cmd.AddCommand(
 		instance.Command(),


### PR DESCRIPTION
Use `--client-id` and `--client-secret` to authenticate with the client credentials flow.